### PR TITLE
Titlebar button accuracy changes and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Create the following boolean or numeric keys as required:
 - `uc.winui.titlebar-style` - 1 to add rounded corners to the titlebar buttons and 2 to add rounded corners and accent-colored glyphs when hovering over them
 - `uc.winui.transparent-urlbar` - Makes the URL bar transparent
 - `uc.winui.urlbar-extra-separators` - Add highlighted separators to either side of URL bar
+- `uc.winui.native-titlebar-button-metrics` - Changes the metrics of the titlebar buttons (close/maximize/restore/minimize) to be more like the native ones
 
 ### Layout
 

--- a/chrome/global/colors.css
+++ b/chrome/global/colors.css
@@ -193,23 +193,23 @@
   }
 
   .titlebar-button:not(.titlebar-close):hover {
-    background-color: color-mix(in srgb, currentColor 11%, transparent) !important;
+    background-color: light-dark(#0000000A, #FFFFFF0F) !important;
 
     &:active {
-      background-color: color-mix(in srgb, currentColor 20%, transparent) !important;
+      background-color: light-dark(#00000006, #FEFEFE0B) !important;
     }
   }
 
   .titlebar-close:hover {
     stroke: white !important;
-    background-color: #e81123 !important;
+    background-color: #C42B1C !important;
 
     &:active {
-      background-color: #DC5C66 !important;
+      background-color: #C32B1BE5 !important;
     }
 
     toolbar[brighttext] &:active {
-      background-color: #971821 !important;
+      background-color: #C32B1BE5 !important;
     }
   }
 

--- a/chrome/toolbar/tabbar.css
+++ b/chrome/toolbar/tabbar.css
@@ -216,7 +216,7 @@
 }
 
 /* Native titlebar button metrics */
-@media -moz-pref("uc.tweak.native-titlebar-button-metrics") {
+@media -moz-pref("uc.winui.native-titlebar-button-metrics") {
   .titlebar-button{
     height: 29px !important;
     width: 45px !important;

--- a/chrome/toolbar/tabbar.css
+++ b/chrome/toolbar/tabbar.css
@@ -214,6 +214,19 @@
     }
   }
 }
+
+/* Native titlebar button metrics */
+@media -moz-pref("uc.tweak.native-titlebar-button-metrics") {
+  .titlebar-button{
+    height: 29px !important;
+    width: 45px !important;
+    display: block;
+  }
+  .titlebar-min, .titlebar-max, .titlebar-restore{
+    margin-right: 1px !important;
+  }
+}
+
 /* #endregion */
 
 

--- a/chrome/toolbar/tabbar.css
+++ b/chrome/toolbar/tabbar.css
@@ -225,6 +225,9 @@
   .titlebar-min, .titlebar-max, .titlebar-restore{
     margin-right: 1px !important;
   }
+  .titlebar-button::before{
+    margin-top: 1px;
+  }
 }
 
 /* #endregion */

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -4201,7 +4201,13 @@ menupopup#ContentSelectDropdownPopup, menuitem {
 .titlebar-close:hover,
 :root:not(:-moz-window-inactive) .titlebar-close:hover,
 :root:-moz-window-inactive .titlebar-close:hover {
-  background-color: #c42b1c !important;
+  background-color: #C42B1C !important
+}
+
+.titlebar-close:active,
+:root:not(:-moz-window-inactive) .titlebar-close:active,
+:root:-moz-window-inactive .titlebar-close:active {
+  background-color: #C32B1BE5 !important
 }
 
 /* Nightly window controls now use font icons */


### PR DESCRIPTION
Hello! Big fan of this theme, crazy how accurate and in-depth it goes.

I made a few changes regarding the titlebar buttons for you to review.

* Colors changed to be more accurate, pulled from the DWMWINDOW image from Windows 11's msstyles.
* Added an option to size the titlebar buttons like they are in normal, native programs.

<img width="155" height="116" alt="image" src="https://github.com/user-attachments/assets/378809e4-034e-460a-8834-6a90470e8716" />

_Example of updated colors and native sizing option._